### PR TITLE
Fix Bigint multiplication bug

### DIFF
--- a/__tests__/bs_Bigint_test.ml
+++ b/__tests__/bs_Bigint_test.ml
@@ -74,6 +74,25 @@ describe "Bigint" (fun () ->
   test "pow" (fun () ->
     expect @@ Bigint.(pow (of_int 4) 4) |> toEqual (Bigint.of_int 256));
 
+  (* test that multiplications are handled correctly *)
+  test "1 * 1 = 1" (fun () ->
+    expect @@ Bigint.(mul one one) |> toEqual (Bigint.of_int 1));
+  
+  test "1 * 0 = 0" (fun () ->
+    expect @@ Bigint.(mul one zero) |> toEqual Bigint.zero);
+  
+  test "0 * 0 = 0" (fun () ->
+    expect @@ Bigint.(mul zero zero) |> toEqual Bigint.zero);
+
+  test "-1 * 1 = -1" (fun () ->
+    expect @@ Bigint.(mul (of_int (-1)) one) |> toEqual (Bigint.of_int (-1)));
+
+  test "20 * 2 = 40" (fun () ->
+    expect @@ Bigint.(mul (of_int 20) (of_int 2)) |> toEqual (Bigint.of_int 40));
+  
+  test "20 * -1 = -20" (fun () ->
+    expect @@ Bigint.(mul (of_int 20) (of_int (-1))) |> toEqual (Bigint.of_int (-20)));
+
   (* test that div handles signs correctly *)
   test "div" (fun () ->
     expect @@ Bigint.(div (of_int 6) (of_int 3)) |> toEqual (Bigint.of_int 2));

--- a/lib/js/__tests__/bs_Bigint_test.js
+++ b/lib/js/__tests__/bs_Bigint_test.js
@@ -82,6 +82,30 @@ Jest.test("pow", (function () {
         return Jest.Expect[/* toEqual */12](Bigint.of_int(256), Jest.Expect[/* expect */0](Bigint.pow(Bigint.of_int(4), 4)));
       }));
 
+Jest.test("1 * 1 = 1", (function () {
+        return Jest.Expect[/* toEqual */12](Bigint.of_int(1), Jest.Expect[/* expect */0](Bigint.mul(Bigint.one, Bigint.one)));
+      }));
+
+Jest.test("1 * 0 = 0", (function () {
+        return Jest.Expect[/* toEqual */12](Bigint.zero, Jest.Expect[/* expect */0](Bigint.mul(Bigint.one, Bigint.zero)));
+      }));
+
+Jest.test("0 * 0 = 0", (function () {
+        return Jest.Expect[/* toEqual */12](Bigint.zero, Jest.Expect[/* expect */0](Bigint.mul(Bigint.zero, Bigint.zero)));
+      }));
+
+Jest.test("-1 * 1 = -1", (function () {
+        return Jest.Expect[/* toEqual */12](Bigint.of_int(-1), Jest.Expect[/* expect */0](Bigint.mul(Bigint.of_int(-1), Bigint.one)));
+      }));
+
+Jest.test("20 * 2 = 40", (function () {
+        return Jest.Expect[/* toEqual */12](Bigint.of_int(40), Jest.Expect[/* expect */0](Bigint.mul(Bigint.of_int(20), Bigint.of_int(2))));
+      }));
+
+Jest.test("20 * -1 = -20", (function () {
+        return Jest.Expect[/* toEqual */12](Bigint.of_int(-20), Jest.Expect[/* expect */0](Bigint.mul(Bigint.of_int(20), Bigint.of_int(-1))));
+      }));
+
 Jest.test("div", (function () {
         return Jest.Expect[/* toEqual */12](Bigint.of_int(2), Jest.Expect[/* expect */0](Bigint.div(Bigint.of_int(6), Bigint.of_int(3))));
       }));

--- a/lib/js/src/Bigint.js
+++ b/lib/js/src/Bigint.js
@@ -285,10 +285,7 @@ function mul$prime(list1, list2$prime, powerof2) {
   if (cmp(powerof2, list1) === 1) {
     return /* tuple */[
             list1,
-            /* :: */[
-              0,
-              /* [] */0
-            ]
+            /* [] */0
           ];
   } else {
     var match = mul$prime(list1, add$prime(list2$prime, list2$prime, 0), add$prime(powerof2, powerof2, 0));

--- a/src/Bigint.ml
+++ b/src/Bigint.ml
@@ -109,7 +109,7 @@ let double listy = add' listy listy 0
 
 let rec mul' list1 list2' powerof2 =
   if (cmp powerof2 list1) = 1
-  then list1, [0]
+  then list1, []
   else let remainder, product =
     mul' list1 (double list2') (double powerof2)
     in if (cmp remainder powerof2) = -1


### PR DESCRIPTION
Hello,

I stumbled upon a multiplication bug in the library while using it. Here's a reproducible example:
```reason
open Bigint;

Js.log(zero); // [ 0, 0 ]
Js.log2(one * zero, one * zero == zero); // [ 0, [ 0 ] ] false
Js.log2(zero * zero, zero * zero == zero); // [ 0, [ 0 ] ] false
```

In this PR, I've added tests specifically to detect this bug along with some other tests to sanity check the `mul` operator. I've also added what I think might be the correct solution to the bug.

I have just started learning ReasonML and have never written OCaml, so feel free to comment with feedback!